### PR TITLE
Fix an overflow bug that causes black blobs in some decoded images.

### DIFF
--- a/CoreJ2K/j2k/entropy/decoder/StdEntropyDecoder.cs
+++ b/CoreJ2K/j2k/entropy/decoder/StdEntropyDecoder.cs
@@ -910,7 +910,7 @@ namespace CoreJ2K.j2k.entropy.decoder
 			sscanw = cblk.w + 2;
 			jstep = sscanw * StdEntropyCoderOptions.STRIPE_HEIGHT / 2 - cblk.w;
 			kstep = dscanw * StdEntropyCoderOptions.STRIPE_HEIGHT - cblk.w;
-			setmask = (3 << bp) >> 1;
+			setmask = (int)(((long)3<<bp)>>1);
 			data = (int[]) cblk.Data;
 			nstripes = (cblk.h + StdEntropyCoderOptions.STRIPE_HEIGHT - 1) / StdEntropyCoderOptions.STRIPE_HEIGHT;
 			causal = (options & StdEntropyCoderOptions.OPT_VERT_STR_CAUSAL) != 0;
@@ -1224,7 +1224,7 @@ namespace CoreJ2K.j2k.entropy.decoder
 			sscanw = cblk.w + 2;
 			jstep = sscanw * StdEntropyCoderOptions.STRIPE_HEIGHT / 2 - cblk.w;
 			kstep = dscanw * StdEntropyCoderOptions.STRIPE_HEIGHT - cblk.w;
-			setmask = (3 << bp) >> 1;
+			setmask = (int)(((long)3<<bp)>>1);
 			data = (int[]) cblk.Data;
 			nstripes = (cblk.h + StdEntropyCoderOptions.STRIPE_HEIGHT - 1) / StdEntropyCoderOptions.STRIPE_HEIGHT;
 			causal = (options & StdEntropyCoderOptions.OPT_VERT_STR_CAUSAL) != 0;
@@ -1865,7 +1865,7 @@ namespace CoreJ2K.j2k.entropy.decoder
 			sscanw = cblk.w + 2;
 			jstep = sscanw * StdEntropyCoderOptions.STRIPE_HEIGHT / 2 - cblk.w;
 			kstep = dscanw * StdEntropyCoderOptions.STRIPE_HEIGHT - cblk.w;
-			setmask = (3 << bp) >> 1;
+			setmask = (int)(((long)3<<bp)>>1);
 			data = (int[]) cblk.Data;
 			nstripes = (cblk.h + StdEntropyCoderOptions.STRIPE_HEIGHT - 1) / StdEntropyCoderOptions.STRIPE_HEIGHT;
 			causal = (options & StdEntropyCoderOptions.OPT_VERT_STR_CAUSAL) != 0;


### PR DESCRIPTION
Very sorry, I cannot share the image that exposes this bug because I am a child abuse pediatrician, and the image file that exposes the bug contains confidential information.  (I promise you -- you really don't want to see most of the pictures I analyze at work.)

Anyway, I had a bug that added a bunch of black blobs to a black and white image.  Google found me a similar bug report in the java version of this project several forks and ports ago.  On a whim I decided to try the patch from Java on this codebase and -- it worked.  If you would consider accepting this merge request and pushing a new version to NuGet (eventually) I can have my bug fixed and we can avoid yet another fork of this project.

The Java diff that forms the basis for this fix is at:
https://github.com/faceless2/jpeg2000/commit/b20342956ac5d05bb97522ddeb41e9bed5abfa95

The code overflows an int in bp (bitplanes) is 30.  They have a complicated fix.  I just do the shifting in a long (which is essentially a free conversion on a 64 bit processor) and then cast it back to int when  the shifting is done.  (Also essentially free on most 64 bit processors.)

This little fix isn't enough to copyright -- but if it was any intellectual property that I own in this 10 bytes of code (which is none) is a free gift to you.  I hope you find it useful.