### PR TITLE
Fix a few bugs

### DIFF
--- a/CoreJ2K/J2kImage.cs
+++ b/CoreJ2K/J2kImage.cs
@@ -248,7 +248,7 @@ namespace CoreJ2K
             // **** Copy to Bitmap ****
 
             var bitsUsed = new int[numComps];
-            for (var j = 0; j < numComps; ++j) bitsUsed[j] = decodedImage.getNomRangeBits(numComps - 1 - j);
+            for (var j = 0; j < numComps; ++j) bitsUsed[j] = decodedImage.getNomRangeBits(j);
 
             var dst = new InterleavedImage(imgWidth, decodedImage.ImgHeight, numComps, bitsUsed);
 
@@ -488,7 +488,7 @@ namespace CoreJ2K
             // **** Copy to Bitmap ****
 
             var bitsUsed = new int[numComps];
-            for (var j = 0; j < numComps; ++j) bitsUsed[j] = decodedImage.getNomRangeBits(numComps - 1 - j);
+            for (var j = 0; j < numComps; ++j) bitsUsed[j] = decodedImage.getNomRangeBits(j);
 
             var dst = new InterleavedImage(imgWidth, decodedImage.ImgHeight, numComps, bitsUsed);
 

--- a/CoreJ2K/j2k/codestream/reader/PktDecoder.cs
+++ b/CoreJ2K/j2k/codestream/reader/PktDecoder.cs
@@ -1695,11 +1695,9 @@ namespace CoreJ2K.j2k.codestream.reader
             // Read marker into array 'sopArray'
             ehs.readFully(sopArray, 0, Markers.SOP_LENGTH);
 
-            // Check if this is the correct marker
-            val = sopArray[0];
-            val <<= 8;
-            val |= sopArray[1];
-            if (val != Markers.SOP)
+            // Check if this is the correct marker (Markers.EPH is a negative short -> cast to short)
+            var marker = (short)((sopArray[0] << 8) | sopArray[1]);
+            if (marker != Markers.SOP)
             {
                 throw new InvalidOperationException("Corrupted Bitstream: Could not parse SOP " + "marker !");
             }
@@ -1740,7 +1738,6 @@ namespace CoreJ2K.j2k.codestream.reader
         /// </param>
         public virtual void readEPHMarker(PktHeaderBitReader bin)
         {
-            int val;
             var ephArray = new byte[2];
 
             if (bin.usebais)
@@ -1752,11 +1749,9 @@ namespace CoreJ2K.j2k.codestream.reader
                 bin.in_Renamed.readFully(ephArray, 0, Markers.EPH_LENGTH);
             }
 
-            // Check if this is the correct marker
-            val = ephArray[0];
-            val <<= 8;
-            val |= ephArray[1];
-            if (val != Markers.EPH)
+            // Check if this is the correct marker (Markers.EPH is a negative short -> cast to short)
+            var marker = (short)((ephArray[0] << 8) | ephArray[1]);
+            if (marker != Markers.EPH)
             {
                 throw new InvalidOperationException("Corrupted Bitstream: Could not parse EPH " + "marker ! ");
             }

--- a/CoreJ2K/j2k/wavelet/synthesis/InvWTFull.cs
+++ b/CoreJ2K/j2k/wavelet/synthesis/InvWTFull.cs
@@ -704,20 +704,10 @@ namespace CoreJ2K.j2k.wavelet.synthesis
                     }
                 }
 
-                // If a reconstructed block exists, update its dimensions and Data pointer to the rented buffer
-                if (reconstructedComps != null && i < reconstructedComps.Length && reconstructedComps[i] != null)
+                // The wavelet data must be reconstructed since we've switched to a different tile.
+                if (reconstructedComps != null && i < reconstructedComps.Length)
                 {
-                    var db = reconstructedComps[i];
-                    db.w = newWidth;
-                    db.h = newHeight;
-                    if (db is DataBlkFloat && rentedFloatBuffers[i] != null)
-                    {
-                        db.Data = rentedFloatBuffers[i];
-                    }
-                    else if (db is DataBlkInt && rentedIntBuffers[i] != null)
-                    {
-                        db.Data = rentedIntBuffers[i];
-                    }
+                    reconstructedComps[i] = null;
                 }
             }
 
@@ -792,19 +782,10 @@ namespace CoreJ2K.j2k.wavelet.synthesis
                     }
                 }
 
-                if (reconstructedComps != null && i < reconstructedComps.Length && reconstructedComps[i] != null)
+                // The wavelet data must be reconstructed since we've switched to a different tile.
+                if (reconstructedComps != null && i < reconstructedComps.Length)
                 {
-                    var db = reconstructedComps[i];
-                    db.w = newWidth;
-                    db.h = newHeight;
-                    if (db is DataBlkFloat && rentedFloatBuffers[i] != null)
-                    {
-                        db.Data = rentedFloatBuffers[i];
-                    }
-                    else if (db is DataBlkInt && rentedIntBuffers[i] != null)
-                    {
-                        db.Data = rentedIntBuffers[i];
-                    }
+                    reconstructedComps[i] = null;
                 }
             }
         }


### PR DESCRIPTION
First off: you are doing an AMAZING work here with no praise! ❤️

I found three bugs when loading the following image: https://filesamples.com/samples/image/jp2/sample1.jp2

1. SOP marker validation in PktDecoder is wrong (`short` casting):
```diff
-val = sopArray[0];
-val <<= 8;
-val |= sopArray[1];
-if (val != Markers.SOP)
+var marker = (short)((sopArray[0] << 8) | sopArray[1]);
+if (marker != Markers.SOP)
```
2. `InvWTFull.cs` tile reconstruction:
```cs
if (reconstructedComps[compIndex] == null)
{
    // Only reconstructs if buffer is null
    waveletTreeReconstruction(...);
}
```

When `setTile()` is called, it updates buffer dimensions, but never sets `reconstructedComps[i] = null` to force reconstruction of the new tile. So all tiles after the first one keep returning data from tile (0,0).

```diff
if (reconstructedComps != null && i < reconstructedComps.Length)
{
-// reconstructedComps[i] logic
+reconstructedComps[i] = null;
}
```

3. `J2kImage.cs` copying to bitmap:
```diff
var bitsUsed = new int[numComps];
-for (var j = 0; j < numComps; ++j) bitsUsed[j] = decodedImage.getNomRangeBits(numComps - 1 - j);
+for (var j = 0; j < numComps; ++j) bitsUsed[j] = decodedImage.getNomRangeBits(j);
```

We pass `bitsUsed` to `InterleavedImage`, which expects `bitsUsed[i]` to correspond to component `i`, so we can't reverse the order here.